### PR TITLE
Update title and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# MID360 Remote Controller
+# Remote Mandeye Controller for HDMapping
 
 This repository provides a lightweight web application for remotely
-controlling a Livox MID360 LiDAR. The web interface exposes controls to
-start and stop recordings and displays a list of previous recordings.
-No physical buttons or switches are required; all interaction happens
-through the browser.
+controlling a Livox MID360 LiDAR. It is inspired by and compatible with
+[mandeye_controller](https://github.com/JanuszBedkowski/mandeye_controller)
+and [HDMapping](https://github.com/MapsHD/HDMapping). The web interface
+exposes controls to start and stop recordings and displays a list of
+previous recordings. No physical buttons or switches are required; all
+interaction happens through the browser.
 
 ## Features
 - Start a new LiDAR recording.
@@ -16,16 +18,28 @@ directory and logs metadata in `recordings/recordings.json`. Replace the
 mocked sections in `recording_manager.py` with calls to the actual Livox
 SDK for hardware integration.
 
-## Getting Started
-1. Install dependencies:
+## Installation
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/<your-username>/tecscanner.git
+   cd tecscanner
+   ```
+2. (Optional) create and activate a virtual environment:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install Python dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the development server:
+
+## Running
+1. Start the development server:
    ```bash
    flask --app webapp run
    ```
-3. Open a browser at [http://localhost:5000](http://localhost:5000) to
+2. Open a browser at [http://localhost:5000](http://localhost:5000) to
    control the scanner.
 
 ## API Endpoints

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Mandeye MID360 Controller</title>
+    <title>Remote Mandeye Controller for HDMapping</title>
   </head>
   <body>
-    <h1>MID360 Controller</h1>
+    <h1>Remote Mandeye Controller for HDMapping</h1>
     <p>Status: <span id="status">{{ 'recording' if status.recording else 'idle' }}</span></p>
     <button onclick="startRec()">Start</button>
     <button onclick="stopRec()">Stop</button>


### PR DESCRIPTION
## Summary
- rename project to **Remote Mandeye Controller for HDMapping** and credit related projects
- document installation steps and how to run the server
- update web UI titles to match new project name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f3cb68304832abb8a065196215321