### PR TITLE
Handle recording start errors

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -14,9 +14,16 @@ def index():
 
 @app.post('/start')
 def start_recording():
-    if manager.start_recording():
+    started, error = manager.start_recording()
+    if started:
         return {'status': 'recording started'}
-    return {'status': 'already recording'}, 400
+    if error == 'already_active':
+        # A recording is already running
+        return {'status': 'already recording'}, 409
+    if error == 'spawn_failed':
+        # The external recorder process could not be started
+        return {'status': 'failed to start recorder'}, 500
+    return {'status': 'unknown error'}, 500
 
 @app.post('/stop')
 def stop_recording():


### PR DESCRIPTION
## Summary
- Return explicit error codes from `RecordingManager.start_recording` for active recorder and process spawn failures
- Map new start errors to distinct HTTP responses in `/start`

## Testing
- `pytest`
- `python -m py_compile webapp/recording_manager.py webapp/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688f4b69c074832ab37cb8e5f6f50ddd