### PR TITLE
Capture recorder logs and expose via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ to capture real MID360 data.
 - `POST /stop` – end the current recording.
 - `GET /status` – retrieve JSON describing the current state.
 - `GET /recordings` – list metadata for previous recordings.
+- `GET /logs/<log_file>` – fetch recorder output for troubleshooting.
 
 ## License
 See [LICENSE](LICENSE) for license information.

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, Response
 from .recording_manager import RecordingManager
 
 manager = RecordingManager()
@@ -31,3 +31,11 @@ def status():
 @app.get('/recordings')
 def recordings():
     return {'recordings': manager.list_recordings()}
+
+
+@app.get('/logs/<path:log_name>')
+def logs(log_name):
+    content = manager.get_log(log_name)
+    if content is None:
+        return {'error': 'log not found'}, 404
+    return Response(content, mimetype='text/plain')


### PR DESCRIPTION
## Summary
- route Livox recorder stdout/stderr to per-recording log files
- expose log file names in status and recordings list, plus API to fetch log content
- document new log endpoint

## Testing
- `python -m py_compile webapp/recording_manager.py webapp/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f4b83ad00832aa89d187f2d3d79f5