### PR TITLE
Handle recorder process failures in status UI

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -67,7 +67,9 @@
             streamEl.textContent = statusData.lidar_detected ? 'idle' : 'n/a';
             streamEl.style.color = statusData.lidar_detected ? 'black' : 'red';
           }
-          if(!statusData.storage_present){
+          if(statusData.recorder_failed){
+            showMessage(false, 'Recording process failed');
+          }else if(!statusData.storage_present){
             showMessage(false, 'No external USB drive detected');
           }else if(!statusData.lidar_detected){
             showMessage(false, 'No LiDAR detected');
@@ -75,7 +77,7 @@
             showMessage(false, 'No LiDAR data received');
           }else{
             const msg = document.getElementById('messages');
-            if(['No external USB drive detected','No LiDAR detected','No LiDAR data received'].includes(msg.textContent)){
+            if(['Recording process failed','No external USB drive detected','No LiDAR detected','No LiDAR data received'].includes(msg.textContent)){
               msg.textContent = '';
             }
           }


### PR DESCRIPTION
## Summary
- track and expose recorder process failure with a `recorder_failed` flag
- show a red warning in the web UI when the recorder process exits with error

## Testing
- `python -m py_compile webapp/recording_manager.py webapp/__init__.py`
- `python - <<'PY'
from webapp.recording_manager import RecordingManager
import subprocess
m = RecordingManager(mount_roots=[])
m._process = subprocess.Popen(['bash','-c','exit 1'])
m._process.wait()
print(m.status())
PY`

------
https://chatgpt.com/codex/tasks/task_e_688f999e88a0832abed69e9ecb112da8