### PR TITLE
Cache LiDAR probe results

### DIFF
--- a/webapp/recording_manager.py
+++ b/webapp/recording_manager.py
@@ -50,6 +50,10 @@ class RecordingManager:
         self.record_cmd = os.getenv("LIVOX_RECORD_CMD", "save_laz")
         self._last_size = 0
         self._last_size_time: Optional[datetime] = None
+        # Cache the results of probing for a connected LiDAR to avoid
+        # repeatedly spawning the external process in quick succession.
+        self._last_probe_time: Optional[datetime] = None
+        self._last_probe_result: Optional[bool] = None
         self._ensure_storage()
 
     # ---- internal helpers -------------------------------------------------
@@ -108,7 +112,18 @@ class RecordingManager:
         self._write_log(data)
 
     def _probe_lidar(self) -> bool:
-        """Invoke the recorder in detection mode to check for a connected LiDAR."""
+        """Invoke the recorder in detection mode to check for a connected LiDAR.
+
+        The result is cached for a short period to avoid repeatedly spawning
+        the external process when the status endpoint is polled rapidly.
+        """
+        now = datetime.utcnow()
+        if (
+            self._last_probe_time
+            and (now - self._last_probe_time).total_seconds() < 5
+        ):
+            return bool(self._last_probe_result)
+
         try:
             res = subprocess.run(
                 [self.record_cmd, "--check"],
@@ -116,9 +131,13 @@ class RecordingManager:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
             )
-            return res.returncode == 0
+            result = res.returncode == 0
         except (OSError, subprocess.SubprocessError):
-            return False
+            result = False
+
+        self._last_probe_time = now
+        self._last_probe_result = result
+        return result
 
     # ---- public API -------------------------------------------------------
     def start_recording(self) -> tuple[bool, Optional[str]]:
@@ -143,7 +162,12 @@ class RecordingManager:
 
         if not self._ensure_storage():
             return False, "no_storage"
-        if not self._probe_lidar():
+
+        # Use the cached probe result to avoid repeatedly spawning the
+        # detection process when status checks occur immediately before this
+        # call.
+        lidar_detected = self._probe_lidar()
+        if not lidar_detected:
             return False, "no_lidar"
         timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
         self.current_file = self.output_dir / f"recording_{timestamp}.laz"
@@ -191,6 +215,8 @@ class RecordingManager:
             self._process = None
             self.current_file = None
             self.current_started = None
+        # Probe the LiDAR with caching to reduce subprocess overhead when the
+        # status endpoint is polled rapidly.
         lidar_detected = self._probe_lidar()
         lidar_streaming = False
         if self._process and self.current_file:
@@ -212,6 +238,8 @@ class RecordingManager:
             "storage_present": storage,
             "lidar_detected": lidar_detected,
             "lidar_streaming": lidar_streaming,
+            "last_probe_time": self._last_probe_time.isoformat() if self._last_probe_time else None,
+            "last_probe_result": self._last_probe_result,
         }
 
     def list_recordings(self):


### PR DESCRIPTION
## Summary
- cache LiDAR probe results and expose last probe time/result
- reuse cached probe in status and start_recording

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9db85550832ab6a9534366a86da3