### PR TITLE
Add configurable mount roots for recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ to capture real MID360 data.
      ports (defaults mirror the Livox SDK samples using ports 56100–56501).
      Place this file next to the `save_laz` binary or set `LIVOX_SDK_CONFIG`
      to its location.
+6. (Optional) specify where to look for removable storage:
+   - By default the application searches `/media` and `/run/media` for a mounted
+     USB drive. Set the `LIVOX_MOUNT_ROOTS` environment variable to a
+     colon-separated list of paths to check additional locations.
+     ```bash
+     export LIVOX_MOUNT_ROOTS=/media:/mnt/usb
+     ```
 
 ## Running
 1. Start the Livox recorder and web server:

--- a/webapp/recording_manager.py
+++ b/webapp/recording_manager.py
@@ -40,7 +40,14 @@ class RecordingManager:
     """
 
     def __init__(self, mount_roots: Optional[List[str]] = None):
-        self.mount_roots = mount_roots or ["/media", "/run/media"]
+        if mount_roots is not None:
+            self.mount_roots = mount_roots
+        else:
+            env_roots = os.getenv("LIVOX_MOUNT_ROOTS")
+            if env_roots:
+                self.mount_roots = [r for r in env_roots.split(os.pathsep) if r]
+            else:
+                self.mount_roots = ["/media", "/run/media"]
         self.usb_mount: Optional[Path] = None
         self.output_dir: Optional[Path] = None
         self.log_file: Optional[Path] = None


### PR DESCRIPTION
## Summary
- allow `RecordingManager` to read mount roots from the `LIVOX_MOUNT_ROOTS` environment variable
- document the `LIVOX_MOUNT_ROOTS` environment variable in installation instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa1819f1c832a8b580382c1aeb544