### PR TITLE
Display formatted elapsed time and recording size

### DIFF
--- a/webapp/recording_manager.py
+++ b/webapp/recording_manager.py
@@ -197,9 +197,11 @@ class RecordingManager:
                 self.current_started = None
             lidar_detected = self._probe_lidar()
             lidar_streaming = False
+            current_size = None
             if self._process and self.current_file:
                 try:
                     size = self.current_file.stat().st_size
+                    current_size = size
                     now = datetime.utcnow()
                     if size != self._last_size:
                         self._last_size = size
@@ -213,6 +215,7 @@ class RecordingManager:
                 "recording": self._process is not None,
                 "current_file": self.current_file.name if self.current_file else None,
                 "started": self.current_started.isoformat() if self.current_started else None,
+                "current_size": current_size,
                 "storage_present": storage,
                 "lidar_detected": lidar_detected,
                 "lidar_streaming": lidar_streaming,

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -10,7 +10,7 @@
     <p>Status: <span id="status">{{ 'recording' if status.recording else 'idle' }}</span></p>
     <p>Current file: <span id="current_file">{{ status.current_file or 'n/a' }}</span></p>
     <p>Started at: <span id="started">{{ status.started or 'n/a' }}</span></p>
-    <p>Elapsed: <span id="elapsed">0s</span></p>
+    <p>Elapsed: <span id="elapsed">00:00:00 (0.00 MB)</span></p>
     <p>LiDAR connection: <span id="lidar_status">unknown</span></p>
     <p>LiDAR stream: <span id="stream_status">n/a</span></p>
     <button onclick="startRec()">Start</button>
@@ -49,6 +49,20 @@
         msg.style.color = success ? 'green' : 'red';
       }
 
+      function formatDuration(seconds){
+        const h = Math.floor(seconds/3600).toString().padStart(2, '0');
+        const m = Math.floor((seconds % 3600)/60).toString().padStart(2, '0');
+        const s = (seconds % 60).toString().padStart(2, '0');
+        return `${h}:${m}:${s}`;
+      }
+
+      function formatSize(bytes){
+        if(bytes >= 1024*1024*1024){
+          return (bytes/(1024*1024*1024)).toFixed(2)+" GB";
+        }
+        return (bytes/(1024*1024)).toFixed(2)+" MB";
+      }
+
       async function updateStatusAndRecordings(){
         try{
           const statusRes = await fetch('/status');
@@ -80,11 +94,13 @@
                 msg.textContent = '';
               }
             }
+            const sizeStr = formatSize(statusData.current_size || 0);
             if(statusData.recording && statusData.started){
               const elapsedMs = Date.now() - Date.parse(statusData.started);
-              document.getElementById('elapsed').textContent = Math.floor(elapsedMs/1000)+'s';
+              const elapsedStr = formatDuration(Math.floor(elapsedMs/1000));
+              document.getElementById('elapsed').textContent = `${elapsedStr} (${sizeStr})`;
             }else{
-              document.getElementById('elapsed').textContent = '0s';
+              document.getElementById('elapsed').textContent = `00:00:00 (${sizeStr})`;
             }
           }else{
             showMessage(false, 'failed to fetch status');


### PR DESCRIPTION
## Summary
- report current recording file size from `RecordingManager.status`
- show elapsed recording time as HH:MM:SS with file size formatted in MB/GB

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fa1991bd0832a8d9c217e465d3fb7