### PR TITLE
Cache LiDAR detection and reduce client polling

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -140,7 +140,9 @@
       }
 
       // Periodically refresh status to provide live updates
-      setInterval(updateStatusAndRecordings, 2000);
+      // Poll less frequently to reduce server load; a push-based approach
+      // (e.g. WebSockets) could be used in the future.
+      setInterval(updateStatusAndRecordings, 5000);
       updateStatusAndRecordings();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- Cache LiDAR detection results in `RecordingManager` and refresh them periodically in a background thread
- Use the cached detection state in `status()` instead of probing every request
- Reduce web client polling to 5 s and note potential WebSocket push implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fac49b47c832a9080128aef884768