### PR TITLE
Add viewport meta tag to index page

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Remote Mandeye Controller for HDMapping</title>
     <style>
       button:disabled {


### PR DESCRIPTION
## Summary
- add responsive viewport meta tag to index template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688faefd24b0832a8f3f899434b3050a