### PR TITLE
Handle missing external recorder command

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -22,6 +22,8 @@ def start_recording():
         return {'status': 'already recording'}, 409
     if error == 'no_lidar':
         return {'status': 'no lidar detected'}, 400
+    if error == 'no_recorder':
+        return {'status': 'recorder unavailable'}, 500
     if error == 'spawn_failed':
         # The external recorder process could not be started
         return {'status': 'failed to start recorder'}, 500


### PR DESCRIPTION
## Summary
- Resolve Livox recorder command via `shutil.which` and disable recording when not found
- Return a `no_recorder` error when the recorder command is absent and surface it through the API

## Testing
- `python -m py_compile webapp/recording_manager.py webapp/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688faef5aa3c832a9f6812d56bb61f35