### PR TITLE
Add aria live status for messages

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <h1>Remote Mandeye Controller for HDMapping</h1>
-    <div id="messages"></div>
+    <div id="messages" role="status" aria-live="polite"></div>
     <p>Status: <span id="status">{{ 'recording' if status.recording else 'idle' }}</span></p>
     <p>Current file: <span id="current_file">{{ status.current_file or 'n/a' }}</span></p>
     <p>Started at: <span id="started">{{ status.started or 'n/a' }}</span></p>


### PR DESCRIPTION
## Summary
- ensure status messages are announced to assistive tech by adding `role="status"` and `aria-live="polite"`

## Testing
- `node -e "const pa11y=require('pa11y'); pa11y('file://' + process.cwd() + '/webapp/templates/index.html', {chromeLaunchConfig:{args:['--no-sandbox']}}).then(r=>console.log('Issues:', r.issues)).catch(e=>console.error(e));"`


------
https://chatgpt.com/codex/tasks/task_e_688fb1bce8b0832a933b11cdf8cbeb33