### PR TITLE
Add installation and service setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ automounted by the operating system. Metadata is tracked in
 to capture real MID360 data.
 
 ## Installation
+A convenience script is available to install dependencies and build native
+components automatically:
+
+```bash
+bash scripts/install.sh
+```
+
+Alternatively, follow the manual steps below.
+
 1. Clone the repository:
    ```bash
    git clone https://github.com/<your-username>/tecscanner.git
@@ -82,6 +91,11 @@ the limit are appended to `recordings_archive.json` in the same directory.
 2. Open a browser at [http://localhost:5000](http://localhost:5000) or use
    the host's IP address if accessing from another machine to control the
    scanner.
+
+To have the web application start automatically on boot, run
+`scripts/setup_service.sh`. The script creates and enables a `systemd`
+service that launches the Flask application using this repository's virtual
+environment.
 
 ## API Endpoints
 - `POST /start` – begin recording.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Install system and Python dependencies for Tecscanner
+# and build required native components.
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Installing system packages..."
+sudo apt-get update
+sudo apt-get install -y build-essential cmake python3-dev python3-venv
+
+echo "Compiling Livox-SDK2..."
+cd "$PROJECT_ROOT/3rd/Livox-SDK2"
+mkdir -p build && cd build
+cmake ..
+make -j"$(nproc)"
+sudo make install
+
+echo "Building save_laz utility..."
+cd "$PROJECT_ROOT/save_laz"
+cmake -S . -B build
+cmake --build build --config Release
+sudo cp build/save_laz /usr/local/bin/save_laz
+
+cd "$PROJECT_ROOT"
+
+if [ ! -d "$PROJECT_ROOT/.venv" ]; then
+  echo "Creating Python virtual environment..."
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Installation complete."

--- a/scripts/setup_service.sh
+++ b/scripts/setup_service.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Create and enable a systemd service for the Tecscanner Flask app.
+set -e
+
+SERVICE_NAME=tecscanner
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+USER_NAME=${SUDO_USER:-$(whoami)}
+
+PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+if [ ! -f "$PYTHON_BIN" ]; then
+  PYTHON_BIN=$(command -v python3)
+fi
+
+sudo tee /etc/systemd/system/${SERVICE_NAME}.service > /dev/null <<SERVICE
+[Unit]
+Description=Tecscanner Flask Service
+After=network.target
+
+[Service]
+Type=simple
+User=${USER_NAME}
+WorkingDirectory=${PROJECT_ROOT}
+Environment=FLASK_APP=webapp
+ExecStart=${PYTHON_BIN} -m flask run --host=0.0.0.0 --port=5000
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo systemctl daemon-reload
+sudo systemctl enable ${SERVICE_NAME}
+sudo systemctl start ${SERVICE_NAME}
+
+echo "Service ${SERVICE_NAME} installed and started."


### PR DESCRIPTION
## Summary
- add `scripts/install.sh` to build Livox SDK, save_laz, and install Python deps
- add `scripts/setup_service.sh` to install a systemd unit so the Flask app starts on boot
- document automated install and service setup in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe7991a70832aa2c83a5e0d2737c2