### PR TITLE
Quote systemd service paths

### DIFF
--- a/scripts/setup_service.sh
+++ b/scripts/setup_service.sh
@@ -19,9 +19,9 @@ After=network.target
 [Service]
 Type=simple
 User=${USER_NAME}
-WorkingDirectory=${PROJECT_ROOT}
+WorkingDirectory="${PROJECT_ROOT}"
 Environment=FLASK_APP=webapp
-ExecStart=${PYTHON_BIN} -m flask run --host=0.0.0.0 --port=5000
+ExecStart="${PYTHON_BIN}" -m flask run --host=0.0.0.0 --port=5000
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- quote WorkingDirectory and ExecStart in setup_service.sh so paths with spaces work

## Testing
- `bash scripts/setup_service.sh` *(fails: System has not been booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_688ff231c958832a967bfcfe01429e70