### PR TITLE
feat: add icons and accessible labels for status

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -130,7 +130,9 @@
 
       function showMessage(success, message){
         const msg = document.getElementById('messages');
-        msg.textContent = message;
+        const icon = success ? '✅' : '❌';
+        msg.innerHTML = `<span aria-hidden="true">${icon}</span> ${message}`;
+        msg.setAttribute('aria-label', message);
         msg.style.color = success ? 'green' : 'red';
       }
 
@@ -161,15 +163,36 @@
             startBtn.disabled = statusData.recording;
             stopBtn.disabled = !statusData.recording;
             const lidarEl = document.getElementById('lidar_status');
-            lidarEl.textContent = statusData.lidar_detected ? 'connected' : 'disconnected';
-            lidarEl.style.color = statusData.lidar_detected ? 'green' : 'red';
+            if(statusData.lidar_detected){
+              lidarEl.innerHTML = '<span aria-hidden="true">✅</span> connected';
+              lidarEl.setAttribute('aria-label', 'connected');
+              lidarEl.style.color = 'green';
+            }else{
+              lidarEl.innerHTML = '<span aria-hidden="true">❌</span> disconnected';
+              lidarEl.setAttribute('aria-label', 'disconnected');
+              lidarEl.style.color = 'red';
+            }
             const streamEl = document.getElementById('stream_status');
             if(statusData.recording){
-              streamEl.textContent = statusData.lidar_streaming ? 'streaming' : 'no data';
-              streamEl.style.color = statusData.lidar_streaming ? 'green' : 'red';
+              if(statusData.lidar_streaming){
+                streamEl.innerHTML = '<span aria-hidden="true">✅</span> streaming';
+                streamEl.setAttribute('aria-label', 'streaming');
+                streamEl.style.color = 'green';
+              }else{
+                streamEl.innerHTML = '<span aria-hidden="true">❌</span> no data';
+                streamEl.setAttribute('aria-label', 'no data');
+                streamEl.style.color = 'red';
+              }
             }else{
-              streamEl.textContent = statusData.lidar_detected ? 'idle' : 'n/a';
-              streamEl.style.color = statusData.lidar_detected ? 'black' : 'red';
+              if(statusData.lidar_detected){
+                streamEl.textContent = 'idle';
+                streamEl.setAttribute('aria-label', 'idle');
+                streamEl.style.color = 'black';
+              }else{
+                streamEl.innerHTML = '<span aria-hidden="true">❌</span> n/a';
+                streamEl.setAttribute('aria-label', 'not available');
+                streamEl.style.color = 'red';
+              }
             }
             if(!statusData.storage_present){
               showMessage(false, 'No external USB drive detected');
@@ -179,8 +202,9 @@
               showMessage(false, 'No LiDAR data received');
             }else{
               const msg = document.getElementById('messages');
-              if(['No external USB drive detected','No LiDAR detected','No LiDAR data received'].includes(msg.textContent)){
+              if(['No external USB drive detected','No LiDAR detected','No LiDAR data received'].includes(msg.getAttribute('aria-label'))){
                 msg.textContent = '';
+                msg.removeAttribute('aria-label');
               }
             }
             const sizeStr = formatSize(statusData.current_size || 0);


### PR DESCRIPTION
## Summary
- show success/failure messages with check/cross icons and screen reader labels
- add icons and ARIA labels for LiDAR connection and streaming statuses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ff3f060f8832abf970881c45af279