### PR TITLE
Refine recordings list template

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -101,7 +101,10 @@
         <h2>Previous recordings</h2>
         <ul id="recordings">
           {% for r in recordings %}
-            <li>{{ r.folder }} {% if r.started %}(started {{ r.started }}, {% endif %}stopped {{ r.stopped }}, frames {{ r.frames }})</li>
+            <li>
+              {{ r.folder }} {% if r.started %}(started {{ r.started }}, {% endif %}
+              stopped {{ r.stopped }}, frames {{ r.frames }})
+            </li>
           {% endfor %}
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- format previous recordings list item so the frame count placeholder `{{ r.frames }}` stays on a single line

## Testing
- `pytest`
- Rendered `webapp/templates/index.html` with sample data to verify output


------
https://chatgpt.com/codex/tasks/task_e_688ff3dd7fac832ab2ed2e2df5c9efa4