### PR TITLE
Improve USB automount robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,18 @@ sudo install -m 0644 scripts/99-usb-automount.rules /etc/udev/rules.d/
 sudo udevadm control --reload-rules
 ```
 
-Drives will appear under `/media/usb0`, which the app monitors.
+To verify the rule without reconnecting a drive, simulate an add event and
+inspect the logs:
+
+```bash
+sudo udevadm test --action=add /block/sdX1 2>&1 | grep usb-automount
+journalctl -t usb-automount
+```
+
+Replace `sdX1` with the block device you wish to test. Drives will appear
+under `/media/usb0` by default. Use the `MOUNT_ROOT` environment variable or
+pass a second argument in the udev rule to change the mount root, e.g.
+`RUN+="/usr/local/sbin/usb-automount.sh %k /mnt"`.
 
 ### 9. Assign static IP to `eth0`
 

--- a/scripts/usb-automount.sh
+++ b/scripts/usb-automount.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # Simple USB automount script triggered by udev.
 # Mounts devices under /media/usbN on add and unmounts on remove.
-set -e
+# The mount root can be overridden with the MOUNT_ROOT env var or a second arg.
 
-MOUNT_ROOT=/media
+set -u -o pipefail
+
+# Allow overriding the mount root via the second argument or an env var
+MOUNT_ROOT=${2:-${MOUNT_ROOT:-/media}}
 DEVICE="/dev/$1"
+
+log() {
+  logger -t usb-automount "$*"
+}
 
 if [ "$ACTION" = "add" ]; then
   mkdir -p "$MOUNT_ROOT"
@@ -12,15 +19,33 @@ if [ "$ACTION" = "add" ]; then
     MP="$MOUNT_ROOT/usb$N"
     if ! mount | grep -q " $MP "; then
       mkdir -p "$MP"
-      mount "$DEVICE" "$MP"
-      exit 0
+      if mount "$DEVICE" "$MP"; then
+        log "mounted $DEVICE at $MP"
+        exit 0
+      else
+        log "failed to mount $DEVICE at $MP"
+        rmdir "$MP"
+      fi
     fi
   done
+  log "no mount point available for $DEVICE"
+  exit 1
 elif [ "$ACTION" = "remove" ]; then
   MP=$(mount | awk -v dev="$DEVICE" '$1==dev {print $3}')
   if [ -n "$MP" ]; then
-    umount "$MP"
-    rmdir "$MP"
+    if umount "$MP"; then
+      log "unmounted $DEVICE from $MP"
+      rmdir "$MP" || log "failed to remove $MP"
+      exit 0
+    else
+      log "failed to unmount $DEVICE from $MP"
+      exit 1
+    fi
+  else
+    log "device $DEVICE not mounted"
+    exit 1
   fi
+else
+  log "unsupported action: $ACTION for $DEVICE"
+  exit 1
 fi
-exit 0


### PR DESCRIPTION
## Summary
- add logging and mount verification to usb-automount.sh
- allow overriding mount root via env var or second arg
- document how to test udev rule and customize mount root

## Testing
- `bash -n scripts/usb-automount.sh`
- `shellcheck scripts/usb-automount.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892ed97e92c832abea3f89fbbe4d8c9