### PR TITLE
Ensure LiDAR discovery check and exit code handling

### DIFF
--- a/webapp/recording_manager.py
+++ b/webapp/recording_manager.py
@@ -187,13 +187,14 @@ class RecordingManager:
         if not self.record_cmd:
             return False
         try:
-            res = subprocess.run(
+            subprocess.run(
                 [self.record_cmd, "--check"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=5,
+                check=True,
             )
-            return res.returncode == 0
+            return True
         except (OSError, subprocess.SubprocessError):
             return False
 


### PR DESCRIPTION
## Summary
- ensure `save_laz --check` loads config, starts the SDK and waits for LiDAR discovery
- rely on `check=True` in `RecordingManager._probe_lidar` to surface non-zero exit codes

## Testing
- `cmake -S save_laz -B save_laz/build` *(fails: Could not find LASZIP_API_LIBRARY)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892eef48dbc832aabddea3c979aa51a