### PR TITLE
Call setup_service.sh during install when service missing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,4 +100,11 @@ sudo nmcli con mod "$CON_NAME" connection.autoconnect yes
 sudo nmcli con mod "$CON_NAME" connection.interface-name eth0
 sudo nmcli con up "$CON_NAME"
 
+if [ ! -f /etc/systemd/system/tecscanner.service ]; then
+  echo "Setting up Tecscanner systemd service..."
+  "$PROJECT_ROOT/scripts/setup_service.sh"
+else
+  echo "Tecscanner systemd service already installed."
+fi
+
 echo "Installation complete."


### PR DESCRIPTION
## Summary
- Setup Tecscanner systemd service during install if not already present

## Testing
- `bash -n scripts/install.sh`
- `bash -n scripts/setup_service.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893303e51cc832abcbcbd81f6ce1564