### PR TITLE
Print laszip creation error details

### DIFF
--- a/save_laz/save_laz.cpp
+++ b/save_laz/save_laz.cpp
@@ -148,8 +148,14 @@ int main(int argc, char** argv)
 	laszip_POINTER tmp_writer = nullptr;
 	if(laszip_create(&tmp_writer))
 	{
-		std::cerr << "Failed to create laszip writer" << std::endl;
+		const char* msg = nullptr;
+		laszip_get_error_message(tmp_writer, &msg);
+		std::cerr << "Failed to create laszip writer: " << (msg ? msg : "unknown error") << std::endl;
 		LivoxLidarSdkUninit();
+		if(tmp_writer)
+		{
+			laszip_destroy(tmp_writer);
+		}
 		return 1;
 	}
 	writer = tmp_writer;


### PR DESCRIPTION
## Summary
- log detailed error from `laszip_get_error_message` when LASzip writer creation fails

## Testing
- `cmake -S save_laz -B build` *(fails: Could not find LASZIP_API_LIBRARY using the following names: laszip_api)*

------
https://chatgpt.com/codex/tasks/task_e_68933e65ced4832ab50914302598e716