### PR TITLE
Fix LASzip includes and CMake

### DIFF
--- a/save_laz/CMakeLists.txt
+++ b/save_laz/CMakeLists.txt
@@ -1,40 +1,59 @@
 cmake_minimum_required(VERSION 3.10)
 project(save_laz)
 
-# C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# LASzip paths relative to root (because we're now called from root)
-set(LASZIP_ROOT_DIR "${CMAKE_SOURCE_DIR}/3rd/LASzip")
-set(LASZIP_INCLUDE_DIR "${LASZIP_ROOT_DIR}/include") # if headers are in dll/
-set(LASZIP_LIBRARY_DIR "${LASZIP_ROOT_DIR}/lib")
+# --- LASzip ---
+find_path(LASZIP_INCLUDE_DIR
+          NAMES laszip/laszip_api.h
+          PATHS
+            ${CMAKE_SOURCE_DIR}/../3rd/LASzip/include
+            /usr/include
+            /usr/local/include)
 
+find_library(LASZIP_API_LIBRARY
+             NAMES laszip_api
+             PATHS
+               ${CMAKE_SOURCE_DIR}/../3rd/LASzip/lib
+               /usr/lib
+               /usr/lib/x86_64-linux-gnu
+               /usr/local/lib)
 
-# Livox SDK2
+if(NOT LASZIP_INCLUDE_DIR OR NOT LASZIP_API_LIBRARY)
+  message(FATAL_ERROR "LASzip library not found")
+endif()
+
+# --- Livox SDK2 ---
 find_path(LIVOX_SDK2_INCLUDE_DIR
-  NAMES livox_lidar_api.h livox_lidar_def.h
-  PATHS /usr/local/include /usr/include
-  REQUIRED)
+          NAMES livox_lidar_api.h livox_lidar_def.h
+          PATHS
+            ${CMAKE_SOURCE_DIR}/../3rd/Livox-SDK2/include
+            /usr/local/include
+            /usr/include)
 
 find_library(LIVOX_SDK2_LIBRARY
-  NAMES livox_lidar_sdk_shared livox_lidar_sdk
-  PATHS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu
-  REQUIRED)
+             NAMES livox_lidar_sdk_shared livox_lidar_sdk
+             PATHS
+               ${CMAKE_SOURCE_DIR}/../3rd/Livox-SDK2/lib
+               /usr/local/lib
+               /usr/lib
+               /usr/lib/x86_64-linux-gnu)
 
-# Executable
+if(NOT LIVOX_SDK2_INCLUDE_DIR OR NOT LIVOX_SDK2_LIBRARY)
+  message(FATAL_ERROR "Livox SDK2 not found")
+endif()
+
+# --- Executable ---
 add_executable(save_laz save_laz.cpp)
 
-# Includes
 target_include_directories(save_laz PRIVATE
   ${LASZIP_INCLUDE_DIR}
-  ${LIVOX_SDK2_INCLUDE_DIR}
-)
+  ${LIVOX_SDK2_INCLUDE_DIR})
 
-# Link libs
 target_link_libraries(save_laz PRIVATE
-  ${LASZIP_LIBRARY}
+  ${LASZIP_API_LIBRARY}
   ${LIVOX_SDK2_LIBRARY}
   pthread
-  dl
-)
+  dl)
+

--- a/save_laz/save_laz.cpp
+++ b/save_laz/save_laz.cpp
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <laszip_api.h>
+#include <laszip/laszip_api.h>
 #include <livox_lidar_api.h>
 #include <livox_lidar_def.h>
 #include <mutex>


### PR DESCRIPTION
## Summary
- Correct save_laz to include LASzip headers from their installed path.
- Revise CMakeLists to locate LASzip and Livox SDK2 libraries and link them for the save_laz target.

## Testing
- `cmake -S save_laz -B build` *(fails: "Livox SDK2 not found")*

------
https://chatgpt.com/codex/tasks/task_e_68936e5e4ac0832abb8f2bc3b8323322