### PR TITLE
Fix LASzip include paths for save_laz build

### DIFF
--- a/save_laz/CMakeLists.txt
+++ b/save_laz/CMakeLists.txt
@@ -5,22 +5,42 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --- LASzip ---
-find_path(LASZIP_INCLUDE_DIR
-          NAMES laszip/laszip_api.h
+set(LASZIP_ROOT "${CMAKE_SOURCE_DIR}/../3rd/LASzip")
+
+find_path(LASZIP_API_INCLUDE_DIR
+          NAMES laszip_api.h
           PATHS
-            ${CMAKE_SOURCE_DIR}/../3rd/LASzip/include
+            ${LASZIP_ROOT}/dll
+            /usr/include
+            /usr/local/include)
+
+find_path(LASZIP_COMMON_INCLUDE_DIR
+          NAMES laszip_common.h
+          PATHS
+            ${LASZIP_ROOT}/include/laszip
             /usr/include
             /usr/local/include)
 
 find_library(LASZIP_API_LIBRARY
              NAMES laszip_api
              PATHS
-               ${CMAKE_SOURCE_DIR}/../3rd/LASzip/lib
+               ${LASZIP_ROOT}/lib
+               ${LASZIP_ROOT}/build/lib
                /usr/lib
                /usr/lib/x86_64-linux-gnu
                /usr/local/lib)
 
-if(NOT LASZIP_INCLUDE_DIR OR NOT LASZIP_API_LIBRARY)
+find_library(LASZIP_LIBRARY
+             NAMES laszip
+             PATHS
+               ${LASZIP_ROOT}/lib
+               ${LASZIP_ROOT}/build/lib
+               /usr/lib
+               /usr/lib/x86_64-linux-gnu
+               /usr/local/lib)
+
+if(NOT LASZIP_API_INCLUDE_DIR OR NOT LASZIP_COMMON_INCLUDE_DIR OR
+   NOT LASZIP_API_LIBRARY OR NOT LASZIP_LIBRARY)
   message(FATAL_ERROR "LASzip library not found")
 endif()
 
@@ -48,11 +68,13 @@ endif()
 add_executable(save_laz save_laz.cpp)
 
 target_include_directories(save_laz PRIVATE
-  ${LASZIP_INCLUDE_DIR}
+  ${LASZIP_API_INCLUDE_DIR}
+  ${LASZIP_COMMON_INCLUDE_DIR}
   ${LIVOX_SDK2_INCLUDE_DIR})
 
 target_link_libraries(save_laz PRIVATE
   ${LASZIP_API_LIBRARY}
+  ${LASZIP_LIBRARY}
   ${LIVOX_SDK2_LIBRARY}
   pthread
   dl)


### PR DESCRIPTION
## Summary
- adjust save_laz to include LASzip headers from packaged location
- expand CMake configuration to locate LASzip headers and libraries and link against laszip

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: Livox SDK2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893735e9208832aaf8b61c99b036f98