### PR TITLE
Refactor LAZ saver and Livox collector

### DIFF
--- a/save_laz/CMakeLists.txt
+++ b/save_laz/CMakeLists.txt
@@ -12,14 +12,18 @@ find_path(LASZIP_API_INCLUDE_DIR
           PATHS
             ${LASZIP_ROOT}/dll
             /usr/include
-            /usr/local/include)
+            /usr/include/laszip
+            /usr/local/include
+            /usr/local/include/laszip)
 
 find_path(LASZIP_COMMON_INCLUDE_DIR
           NAMES laszip_common.h
           PATHS
             ${LASZIP_ROOT}/include/laszip
             /usr/include
-            /usr/local/include)
+            /usr/include/laszip
+            /usr/local/include
+            /usr/local/include/laszip)
 
 find_library(LASZIP_API_LIBRARY
              NAMES laszip_api
@@ -64,18 +68,25 @@ if(NOT LIVOX_SDK2_INCLUDE_DIR OR NOT LIVOX_SDK2_LIBRARY)
   message(FATAL_ERROR "Livox SDK2 not found")
 endif()
 
-# --- Executable ---
-add_executable(save_laz save_laz.cpp)
+# --- Library and executable ---
+add_library(save_laz_utils
+  save_laz.cpp
+  livox_collector.cpp)
 
-target_include_directories(save_laz PRIVATE
+target_include_directories(save_laz_utils PUBLIC
   ${LASZIP_API_INCLUDE_DIR}
   ${LASZIP_COMMON_INCLUDE_DIR}
-  ${LIVOX_SDK2_INCLUDE_DIR})
+  ${LIVOX_SDK2_INCLUDE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(save_laz PRIVATE
+target_link_libraries(save_laz_utils PUBLIC
   ${LASZIP_API_LIBRARY}
   ${LASZIP_LIBRARY}
   ${LIVOX_SDK2_LIBRARY}
   pthread
   dl)
 
+add_executable(save_laz
+  main.cpp)
+
+target_link_libraries(save_laz PRIVATE save_laz_utils)

--- a/save_laz/livox_collector.cpp
+++ b/save_laz/livox_collector.cpp
@@ -1,0 +1,104 @@
+#include "livox_collector.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <livox_lidar_api.h>
+#include <livox_lidar_def.h>
+#include <thread>
+
+bool LivoxCollector::collect(std::vector<Point>& points,
+                             double& duration,
+                             const std::string& cfg)
+{
+    if(!LivoxLidarSdkInit(cfg.c_str()))
+    {
+        return false;
+    }
+
+    std::atomic_bool running(true);
+    std::atomic_bool frame_done(false);
+
+    struct CallbackCtx
+    {
+        std::vector<Point>* pts;
+        std::atomic_bool* frame_done;
+        std::atomic_bool* running;
+    } ctx{&points, &frame_done, &running};
+
+    auto point_cb = [](uint32_t, const uint8_t, LivoxLidarEthernetPacket* data, void* user)
+    {
+        if(!data || data->data_type != kLivoxLidarCartesianCoordinateHighData)
+        {
+            return;
+        }
+        auto* c = static_cast<CallbackCtx*>(user);
+        auto* pts = reinterpret_cast<LivoxLidarCartesianHighRawPoint*>(data->data);
+        uint64_t ts = 0;
+        std::memcpy(&ts, data->timestamp, sizeof(ts));
+        double gps_time = static_cast<double>(ts) * 1e-9;
+        for(uint32_t i = 0; i < data->dot_num; ++i)
+        {
+            Point p;
+            p.x = 0.001 * pts[i].x;
+            p.y = 0.001 * pts[i].y;
+            p.z = 0.001 * pts[i].z;
+            p.intensity = pts[i].reflectivity;
+            p.tag = pts[i].tag;
+            p.gps_time = gps_time;
+            c->pts->push_back(p);
+        }
+        *(c->frame_done) = true;
+        *(c->running) = false;
+    };
+
+    auto info_cb = [](const uint32_t handle, const LivoxLidarInfo* info, void*)
+    {
+        if(info)
+        {
+            SetLivoxLidarWorkMode(handle, kLivoxLidarNormal, nullptr, nullptr);
+        }
+    };
+
+    SetLivoxLidarPointCloudCallBack(point_cb, &ctx);
+    SetLivoxLidarInfoChangeCallback(info_cb, nullptr);
+    LivoxLidarSdkStart();
+
+    auto start = std::chrono::steady_clock::now();
+    while(running && !frame_done)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if(std::chrono::steady_clock::now() - start > std::chrono::seconds(5))
+        {
+            break;
+        }
+    }
+    duration = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+
+    LivoxLidarSdkUninit();
+    return frame_done.load();
+}
+
+bool LivoxCollector::check(const std::string& cfg)
+{
+    if(!LivoxLidarSdkInit(cfg.c_str()))
+    {
+        return false;
+    }
+    std::atomic_bool lidar_found(false);
+    auto cb = [](const uint32_t, const LivoxLidarInfo* info, void* client_data)
+    {
+        if(info)
+        {
+            *static_cast<std::atomic_bool*>(client_data) = true;
+        }
+    };
+    SetLivoxLidarInfoChangeCallback(cb, &lidar_found);
+    LivoxLidarSdkStart();
+    for(int i = 0; i < 50 && !lidar_found; ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    LivoxLidarSdkUninit();
+    return lidar_found.load();
+}

--- a/save_laz/livox_collector.h
+++ b/save_laz/livox_collector.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "save_laz.h"
+
+#include <string>
+#include <vector>
+
+class LivoxCollector
+{
+public:
+    bool collect(std::vector<Point>& points,
+                 double& duration,
+                 const std::string& cfg);
+    static bool check(const std::string& cfg);
+};

--- a/save_laz/main.cpp
+++ b/save_laz/main.cpp
@@ -1,0 +1,40 @@
+#include "livox_collector.h"
+#include "save_laz.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+int main(int argc, char** argv)
+{
+    if(argc < 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " output.laz" << std::endl;
+        return 1;
+    }
+
+    std::string cfg = "mid360_config.json";
+    if(const char* env = std::getenv("LIVOX_SDK_CONFIG"))
+    {
+        cfg = env;
+    }
+
+    if(std::strcmp(argv[1], "--check") == 0)
+    {
+        return LivoxCollector::check(cfg) ? 0 : 1;
+    }
+
+    std::string output = argv[1];
+    std::vector<Point> points;
+    double capture_duration = 0.0;
+    LivoxCollector collector;
+    if(!collector.collect(points, capture_duration, cfg))
+    {
+        std::cerr << "Failed to collect points" << std::endl;
+        return 1;
+    }
+
+    LazStats stats = saveLaz(output, points, capture_duration);
+    return stats.point_count > 0 ? 0 : 1;
+}

--- a/save_laz/save_laz.cpp
+++ b/save_laz/save_laz.cpp
@@ -1,212 +1,122 @@
-#include <atomic>
+#include "save_laz.h"
+
 #include <chrono>
-#include <csignal>
-#include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <laszip_api.h>
-#include <livox_lidar_api.h>
-#include <livox_lidar_def.h>
-#include <mutex>
-#include <string>
-#include <thread>
-#include <vector>
 
-// Simple utility that streams Livox MID360 data into a LAZ file.
-// The program runs until it receives SIGINT (Ctrl+C) and mirrors the
-// recording format used by the mandeye_controller project.
-
-namespace
+LazStats saveLaz(const std::string& output,
+                 const std::vector<Point>& points,
+                 double capture_duration)
 {
-std::atomic_bool running(true);
-std::atomic_bool frame_done(false);
-laszip_POINTER writer = nullptr;
-laszip_point* laz_point = nullptr;
-std::mutex writer_mutex;
-std::ofstream csv_writer;
+    LazStats stats{};
+    stats.point_count = points.size();
+    stats.capture_duration = capture_duration;
 
-void signalHandler(int)
-{
-	running = false;
-}
+    laszip_POINTER writer = nullptr;
+    if(laszip_create(&writer))
+    {
+        const char* msg = nullptr;
+        laszip_get_error_message(writer, &msg);
+        std::cerr << "Failed to create laszip writer: " << (msg ? msg : "unknown error") << std::endl;
+        if(writer)
+        {
+            laszip_destroy(writer);
+        }
+        return stats;
+    }
 
-void PointCloudCallback(uint32_t, const uint8_t, LivoxLidarEthernetPacket* data, void*)
-{
-	if(!data || data->data_type != kLivoxLidarCartesianCoordinateHighData)
-	{
-		return;
-	}
-	LivoxLidarCartesianHighRawPoint* pts = reinterpret_cast<LivoxLidarCartesianHighRawPoint*>(data->data);
-	laszip_F64 coords[3];
-	std::lock_guard<std::mutex> lk(writer_mutex);
+    struct WriterGuard
+    {
+        laszip_POINTER ptr;
+        bool opened;
+        explicit WriterGuard(laszip_POINTER p) : ptr(p), opened(false) {}
+        ~WriterGuard()
+        {
+            if(ptr)
+            {
+                if(opened)
+                {
+                    laszip_close_writer(ptr);
+                }
+                laszip_destroy(ptr);
+            }
+        }
+    } guard(writer);
 
-	uint64_t ts = 0;
-	std::memcpy(&ts, data->timestamp, sizeof(ts));
-	const double gps_time = static_cast<double>(ts) * 1e-9;
-	for(uint32_t i = 0; i < data->dot_num; ++i)
-	{
-		laz_point->intensity = pts[i].reflectivity;
-		laz_point->gps_time = gps_time;
-		laz_point->user_data = 0;
-		laz_point->classification = pts[i].tag;
-		laz_point->point_source_ID = 0;
-		coords[0] = 0.001 * pts[i].x;
-		coords[1] = 0.001 * pts[i].y;
-		coords[2] = 0.001 * pts[i].z;
-		laszip_set_coordinates(writer, coords);
-		laszip_write_point(writer);
-		csv_writer << coords[0] << ',' << coords[1] << ',' << coords[2] << ',' << static_cast<int>(pts[i].reflectivity) << ',' << gps_time << ',' << 0
-				   << ',' << static_cast<int>(pts[i].tag) << ',' << 0 << '\n';
-	}
+    laszip_header* header = nullptr;
+    laszip_get_header_pointer(writer, &header);
+    header->file_source_ID = 4711;
+    header->version_major = 1;
+    header->version_minor = 2;
+    header->point_data_format = 1;
+    header->point_data_record_length = 28;
+    header->x_scale_factor = 0.0001;
+    header->y_scale_factor = 0.0001;
+    header->z_scale_factor = 0.0001;
 
-	frame_done = true;
-	running = false;
-}
+    if(laszip_open_writer(writer, output.c_str(), 1))
+    {
+        std::cerr << "Failed to open LAZ writer" << std::endl;
+        return stats;
+    }
+    guard.opened = true;
 
-void LidarInfoChangeCallback(const uint32_t handle, const LivoxLidarInfo* info, void*)
-{
-	if(info)
-	{
-		SetLivoxLidarWorkMode(handle, kLivoxLidarNormal, nullptr, nullptr);
-	}
-}
-} // namespace
+    laszip_point* laz_point = nullptr;
+    laszip_get_point_pointer(writer, &laz_point);
 
-int main(int argc, char** argv)
-{
-	if(argc < 2)
-	{
-		std::cerr << "Usage: " << argv[0] << " output.laz" << std::endl;
-		return 1;
-	}
-	if(std::strcmp(argv[1], "--check") == 0)
-	{
-		std::string cfg = "mid360_config.json";
-		if(const char* env = std::getenv("LIVOX_SDK_CONFIG"))
-		{
-			cfg = env;
-		}
-		if(!LivoxLidarSdkInit(cfg.c_str()))
-		{
-			return 1;
-		}
-		std::atomic_bool lidar_found(false);
-		auto cb = [](const uint32_t, const LivoxLidarInfo* info, void* client_data) {
-			if(info)
-			{
-				*static_cast<std::atomic_bool*>(client_data) = true;
-			}
-		};
-		SetLivoxLidarInfoChangeCallback(cb, &lidar_found);
-		LivoxLidarSdkStart();
-		for(int i = 0; i < 50 && !lidar_found; ++i)
-		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
-		}
-		LivoxLidarSdkUninit();
-		return lidar_found ? 0 : 1;
-	}
-	std::string output = argv[1];
-	std::string cfg = "mid360_config.json";
-	if(const char* env = std::getenv("LIVOX_SDK_CONFIG"))
-	{
-		cfg = env;
-	}
-	if(!LivoxLidarSdkInit(cfg.c_str()))
-	{
-		std::cerr << "Livox Init Failed" << std::endl;
-		return 1;
-	}
-	signal(SIGINT, signalHandler);
-	SetLivoxLidarPointCloudCallBack(PointCloudCallback, nullptr);
-	SetLivoxLidarInfoChangeCallback(LidarInfoChangeCallback, nullptr);
-	LivoxLidarSdkStart();
-	struct LaszipWriterGuard
-	{
-		laszip_POINTER ptr;
-		bool opened;
-		explicit LaszipWriterGuard(laszip_POINTER p)
-			: ptr(p)
-			, opened(false)
-		{ }
-		~LaszipWriterGuard()
-		{
-			if(ptr)
-			{
-				if(opened)
-				{
-					laszip_close_writer(ptr);
-				}
-				laszip_destroy(ptr);
-			}
-		}
-	};
+    std::string csv_output = output;
+    auto dot = csv_output.find_last_of('.');
+    if(dot != std::string::npos)
+    {
+        csv_output.replace(dot, std::string::npos, ".csv");
+    }
+    else
+    {
+        csv_output += ".csv";
+    }
+    std::ofstream csv_writer(csv_output);
+    if(!csv_writer)
+    {
+        std::cerr << "Failed to open CSV writer" << std::endl;
+        return stats;
+    }
+    csv_writer << "x,y,z,intensity,gps_time,line_id,tag,laser_id\n";
 
-	laszip_POINTER tmp_writer = nullptr;
-	if(laszip_create(&tmp_writer))
-	{
-		const char* msg = nullptr;
-		laszip_get_error_message(tmp_writer, &msg);
-		std::cerr << "Failed to create laszip writer: " << (msg ? msg : "unknown error") << std::endl;
-		LivoxLidarSdkUninit();
-		if(tmp_writer)
-		{
-			laszip_destroy(tmp_writer);
-		}
-		return 1;
-	}
-	writer = tmp_writer;
-	LaszipWriterGuard writer_guard(writer);
-	laszip_header* header = nullptr;
-	laszip_get_header_pointer(writer, &header);
-	header->file_source_ID = 4711;
-	header->version_major = 1;
-	header->version_minor = 2;
-	header->point_data_format = 1;
-	header->point_data_record_length = 28;
-	header->x_scale_factor = 0.0001;
-	header->y_scale_factor = 0.0001;
-	header->z_scale_factor = 0.0001;
-	if(laszip_open_writer(writer, output.c_str(), 1))
-	{
-		std::cerr << "Failed to open LAZ writer" << std::endl;
-		LivoxLidarSdkUninit();
-		return 1;
-	}
-	writer_guard.opened = true;
-	laszip_get_point_pointer(writer, &laz_point);
+    auto write_start = std::chrono::steady_clock::now();
+    laszip_F64 coords[3];
+    for(const auto& p : points)
+    {
+        laz_point->intensity = p.intensity;
+        laz_point->gps_time = p.gps_time;
+        laz_point->user_data = 0;
+        laz_point->classification = p.tag;
+        laz_point->point_source_ID = 0;
+        coords[0] = p.x;
+        coords[1] = p.y;
+        coords[2] = p.z;
+        laszip_set_coordinates(writer, coords);
+        laszip_write_point(writer);
+        csv_writer << coords[0] << ',' << coords[1] << ',' << coords[2] << ','
+                   << static_cast<int>(p.intensity) << ',' << p.gps_time << ','
+                   << 0 << ',' << static_cast<int>(p.tag) << ',' << 0 << '\n';
+    }
+    auto write_end = std::chrono::steady_clock::now();
 
-	std::string csv_output = output;
-	auto dot = csv_output.find_last_of('.');
-	if(dot != std::string::npos)
-	{
-		csv_output.replace(dot, std::string::npos, ".csv");
-	}
-	else
-	{
-		csv_output += ".csv";
-	}
-	csv_writer.open(csv_output);
-	if(!csv_writer)
-	{
-		std::cerr << "Failed to open CSV writer" << std::endl;
-		LivoxLidarSdkUninit();
-		return 1;
-	}
-	csv_writer << "x,y,z,intensity,gps_time,line_id,tag,laser_id\n";
+    stats.write_duration =
+        std::chrono::duration<double>(write_end - write_start).count();
 
-	auto start_time = std::chrono::steady_clock::now();
-	while(running && !frame_done)
-	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-		auto now = std::chrono::steady_clock::now();
-		if(now - start_time > std::chrono::seconds(5))
-		{
-			break;
-		}
-	}
+    csv_writer.close();
 
-	LivoxLidarSdkUninit();
-	csv_writer.close();
-	return frame_done ? 0 : 1;
+    try
+    {
+        stats.file_size = std::filesystem::file_size(output);
+    }
+    catch(const std::filesystem::filesystem_error&)
+    {
+        stats.file_size = 0;
+    }
+
+    return stats;
 }

--- a/save_laz/save_laz.h
+++ b/save_laz/save_laz.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct Point
+{
+    double x;
+    double y;
+    double z;
+    std::uint8_t intensity;
+    std::uint8_t tag;
+    double gps_time;
+};
+
+struct LazStats
+{
+    std::size_t point_count;
+    double capture_duration;  // seconds
+    double write_duration;    // seconds
+    std::uint64_t file_size;  // bytes
+};
+
+LazStats saveLaz(const std::string& laz_file,
+                 const std::vector<Point>& points,
+                 double capture_duration);


### PR DESCRIPTION
## Summary
- Extract LAZ writing into reusable `saveLaz` utility and expose `LazStats`
- Add `LivoxCollector` to handle SDK setup and point buffering
- Provide simple CLI wiring the collector to the LAZ saver
- Update CMake to build library and CLI

## Testing
- `cmake .. -DLASZIP_API_INCLUDE_DIR=/usr/include/laszip -DLASZIP_COMMON_INCLUDE_DIR=/usr/include/laszip -DLASZIP_API_LIBRARY=/usr/lib/x86_64-linux-gnu/liblaszip_api.so -DLASZIP_LIBRARY=/usr/lib/x86_64-linux-gnu/liblaszip.so .. && make -j$(nproc)` *(fails: Livox SDK2 not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893ad3f8990832a9210e516ce40567b