### PR TITLE
Add buffered decimation and bounds to LAZ writer

### DIFF
--- a/save_laz/save_laz.h
+++ b/save_laz/save_laz.h
@@ -17,6 +17,7 @@ struct Point
 struct LazStats
 {
     std::size_t point_count;
+    std::size_t decimation_step;
     double capture_duration;  // seconds
     double write_duration;    // seconds
     std::uint64_t file_size;  // bytes


### PR DESCRIPTION
## Summary
- Collect Livox points into a buffer before writing
- Compute point cloud bounds and set LAS header min/max
- Add point decimation and expose decimation step in LazStats

## Testing
- `cmake -B build` *(failed: LASzip library not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893afe6da90832ab349913c84147bbe