### PR TITLE
Check Livox SDK 2 libraries and update status bar

### DIFF
--- a/webapp/recording_manager.py
+++ b/webapp/recording_manager.py
@@ -436,7 +436,14 @@ class RecordingManager:
                     lidar_streaming = True
             ip_eth0 = self._get_ip_address("eth0")
             lidar_ip = os.getenv("LIDAR_IP")
-            livox_driver = shutil.which("livox_ros_driver") is not None
+            sdk_files = [
+                "/usr/local/lib/liblivox_lidar_sdk_shared.so",
+                "/usr/local/lib/liblivox_lidar_sdk_static.a",
+                "/usr/local/include/livox_lidar_api.h",
+                "/usr/local/include/livox_lidar_cfg.h",
+                "/usr/local/include/livox_lidar_def.h",
+            ]
+            livox_sdk2 = all(Path(p).exists() for p in sdk_files)
             save_laz_ok = shutil.which("save_laz") is not None
             laszip_ok = shutil.which("laszip") is not None
             free_space = None
@@ -458,7 +465,7 @@ class RecordingManager:
             "lidar_streaming": lidar_streaming,
             "eth0_ip": ip_eth0,
             "lidar_ip": lidar_ip,
-            "livox_driver": livox_driver,
+            "livox_sdk2": livox_sdk2,
             "save_laz": save_laz_ok,
             "laszip": laszip_ok,
             "log_error": self._log_error,

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -108,7 +108,7 @@
     <div id="sysbar">
       <span id="eth0_ip" class="{{ 'ok' if status.eth0_ip else 'bad' }}">{{ status.eth0_ip or 'eth0 ?' }}</span>
       <span id="lidar_ip" class="{{ 'ok' if status.lidar_detected else 'bad' }}">{{ status.lidar_ip or 'lidar ?' }}</span>
-      <span id="livox_driver" class="{{ 'ok' if status.livox_driver else 'bad' }}">driver</span>
+      <span id="livox_sdk2" class="{{ 'ok' if status.livox_sdk2 else 'bad' }}">LivoxSDK2</span>
       <span id="save_laz" class="{{ 'ok' if status.save_laz else 'bad' }}">save_laz</span>
       <span id="laszip" class="{{ 'ok' if status.laszip else 'bad' }}">laszip</span>
       <span id="flash" class="{{ 'ok' if status.storage_present else 'bad' }}">storage</span>
@@ -230,7 +230,7 @@
             stopBtn.disabled = !statusData.recording;
             setIndicator('eth0_ip', statusData.eth0_ip || 'eth0 ?', !!statusData.eth0_ip);
             setIndicator('lidar_ip', statusData.lidar_ip || 'lidar ?', statusData.lidar_detected);
-            setIndicator('livox_driver', 'driver', statusData.livox_driver);
+            setIndicator('livox_sdk2', 'LivoxSDK2', statusData.livox_sdk2);
             setIndicator('save_laz', 'save_laz', statusData.save_laz);
             setIndicator('laszip', 'laszip', statusData.laszip);
             setIndicator('flash', 'storage', statusData.storage_present);


### PR DESCRIPTION
## Summary
- detect Livox SDK 2 by verifying required library and header files
- rename web UI driver indicator to "LivoxSDK2"

## Testing
- `python -m py_compile webapp/recording_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68941489cc54832a88581a93780c751d