### PR TITLE
Use integer nanosecond timestamps for IMU data

### DIFF
--- a/save_laz/imu_writer.cpp
+++ b/save_laz/imu_writer.cpp
@@ -1,7 +1,6 @@
 #include "imu_writer.h"
 
 #include <iostream>
-#include <iomanip>
 
 bool openImuCsv(ImuWriter& writer, const std::string& filename)
 {
@@ -11,7 +10,7 @@ bool openImuCsv(ImuWriter& writer, const std::string& filename)
         std::cerr << "Failed to open IMU CSV writer" << std::endl;
         return false;
     }
-    writer.file << "timestamp,gyroX,gyroY,gyroZ,accX,accY,accZ,imuId,timestampUnix\n";
+    writer.file << "timestamp gyroX gyroY gyroZ accX accY accZ imuId timestampUnix\n";
     return true;
 }
 
@@ -21,10 +20,10 @@ void writeImu(ImuWriter& writer, const ImuData& imu)
     {
         return;
     }
-    writer.file << std::fixed << std::setprecision(9) << imu.timestamp << ','
-                << imu.gyro_x << ',' << imu.gyro_y << ',' << imu.gyro_z << ','
-                << imu.acc_x << ',' << imu.acc_y << ',' << imu.acc_z << ','
-                << imu.imu_id << ',' << imu.timestamp_unix << '\n';
+    writer.file << imu.timestamp << ' '
+                << imu.gyro_x << ' ' << imu.gyro_y << ' ' << imu.gyro_z << ' '
+                << imu.acc_x << ' ' << imu.acc_y << ' ' << imu.acc_z << ' '
+                << imu.imu_id << ' ' << imu.timestamp_unix << '\n';
 }
 
 void closeImuCsv(ImuWriter& writer)

--- a/save_laz/livox_collector.cpp
+++ b/save_laz/livox_collector.cpp
@@ -67,15 +67,18 @@ bool LivoxCollector::collect(std::vector<Point>& points,
         uint64_t ts = 0;
         std::memcpy(&ts, data->timestamp, sizeof(ts));
         ImuData imu;
-        imu.timestamp = static_cast<double>(ts) * 1e-9;
+        imu.timestamp = ts;
         imu.gyro_x = imu_raw->gyro_x;
         imu.gyro_y = imu_raw->gyro_y;
         imu.gyro_z = imu_raw->gyro_z;
         imu.acc_x = imu_raw->acc_x;
         imu.acc_y = imu_raw->acc_y;
         imu.acc_z = imu_raw->acc_z;
-        imu.imu_id = handle;
-        imu.timestamp_unix = ts;
+        imu.imu_id = static_cast<std::uint16_t>(handle);
+        imu.timestamp_unix = static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::system_clock::now().time_since_epoch())
+                .count());
         c->imus->push_back(imu);
     };
 

--- a/save_laz/save_laz.h
+++ b/save_laz/save_laz.h
@@ -19,14 +19,14 @@ struct Point
 
 struct ImuData
 {
-    double timestamp;
+    std::uint64_t timestamp;
     float gyro_x;
     float gyro_y;
     float gyro_z;
     float acc_x;
     float acc_y;
     float acc_z;
-    std::uint32_t imu_id;
+    std::uint16_t imu_id;
     std::uint64_t timestamp_unix;
 };
 


### PR DESCRIPTION
## Summary
- Switch IMU timestamp to `uint64_t` nanoseconds and `imu_id` to `uint16_t`
- Output IMU CSV fields with spaces and updated header
- Capture and log IMU data with integer timestamps and Unix time

## Testing
- `cmake ..` *(fails: The source directory /workspace/tecscanner/3rd/LASzip does not contain a CMakeLists.txt file; Livox SDK2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f626bf70832aa41a5496bb97d145