### PR TITLE
Filter log noise from LiDAR serial number dumps

### DIFF
--- a/save_laz/utils.py
+++ b/save_laz/utils.py
@@ -14,6 +14,7 @@ import json
 import platform
 import shutil
 import subprocess
+import re
 from typing import Iterable
 
 
@@ -40,12 +41,16 @@ def write_lidar_sn(path: Path) -> None:
         )
         raw_lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
         lines: list[str] = []
-        for idx, entry in enumerate(raw_lines):
-            parts = entry.split()
-            if len(parts) >= 2:
-                lines.append(f"{parts[0]} {parts[1]}")
-            else:
-                lines.append(f"{idx} {parts[0]}")
+        for entry in raw_lines:
+            m = re.search(r"(\d+)\s+(\S+)", entry)
+            if m:
+                lines.append(f"{m.group(1)} {m.group(2)}")
+        # If nothing matched but output exists, fall back to enumerating
+        if not lines:
+            for idx, entry in enumerate(raw_lines):
+                tokens = entry.split()
+                if tokens:
+                    lines.append(f"{idx} {tokens[-1]}")
     except (OSError, subprocess.SubprocessError):
         lines = []
     _write_lines(path, lines)


### PR DESCRIPTION
## Summary
- make `write_lidar_sn` robust against log prefixes in `save_laz --sn` output by extracting numeric id/serial pairs with regex
- fall back to simple enumeration when no structured data is found

## Testing
- `python -m py_compile save_laz/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68959dabdbd0832ab5ae1a36f02b5ad4