### PR TITLE
Map lidar handles to sequential IDs

### DIFF
--- a/save_laz/livox_collector.h
+++ b/save_laz/livox_collector.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -16,11 +17,12 @@ public:
                  const std::string& cfg);
     static bool check(const std::string& cfg);
 
-    const std::vector<std::pair<std::uint32_t, std::string>>& serials() const
+    const std::vector<std::pair<std::uint16_t, std::string>>& serials() const
     {
         return serials_;
     }
 
 private:
-    std::vector<std::pair<std::uint32_t, std::string>> serials_;
+    std::vector<std::pair<std::uint16_t, std::string>> serials_;
+    std::unordered_map<std::uint32_t, std::uint16_t> handle_to_id_;
 };


### PR DESCRIPTION
## Summary
- Map lidar handles to sequential IDs and track serial numbers
- Use handle-to-ID mapping so IMU data records the correct lidar ID

## Testing
- `cmake -S save_laz -B save_laz/build` *(fails: source directory 3rd/LASzip does not contain a CMakeLists.txt file, Livox SDK2 not found)*
- `cmake --build save_laz/build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_6895bcdbabe0832a9858933ef2318270