### PR TITLE
Remove GPIO references and update build process

### DIFF
--- a/save_laz/utils.py
+++ b/save_laz/utils.py
@@ -84,9 +84,9 @@ def write_status(path: Path, **extra) -> None:
 
     The resulting structure mirrors ``produceReport`` from the reference
     repository and includes the fields ``name``, ``hash``, ``version``,
-    ``hardware``, ``arch``, ``state``, ``livox``, ``gpio``,
-    ``fs_benchmark``, ``fs``, ``gnss`` and ``lastLazStatus``.  Any extra
-    keyword arguments are merged into the top level of the JSON.
+    ``hardware``, ``arch``, ``state``, ``livox``, ``fs_benchmark``, ``fs``,
+    ``gnss`` and ``lastLazStatus``.  Any extra keyword arguments are merged into
+    the top level of the JSON.
     """
     data = {
         "name": platform.node(),
@@ -96,7 +96,6 @@ def write_status(path: Path, **extra) -> None:
         "arch": platform.architecture()[0],
         "state": extra.pop("state", None),
         "livox": extra.pop("livox", {}),
-        "gpio": extra.pop("gpio", {}),
         "fs_benchmark": extra.pop("fs_benchmark", {}),
         "fs": extra.pop("fs", {}),
         "gnss": extra.pop("gnss", {}),

--- a/scripts/compile_save_laz.sh
+++ b/scripts/compile_save_laz.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# Compile and install the save_laz utility.
+# Compile and install the save_laz utility together with its dependencies.
 set -e
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CODE_DIR="$PROJECT_ROOT/save_laz"
 
-if [ ! -f /usr/local/bin/save_laz ]; then
-  echo "Compiling save_laz utility..."
-  cmake -S "$PROJECT_ROOT/save_laz" -B "$PROJECT_ROOT/save_laz/build"
-  cmake --build "$PROJECT_ROOT/save_laz/build" --config Release
-  sudo install -m 0755 "$PROJECT_ROOT/save_laz/build/save_laz" /usr/local/bin/save_laz
-else
-  echo "save_laz utility already installed."
-fi
+# Ensure third-party libraries are available
+"$PROJECT_ROOT/scripts/build_livox_sdk2.sh"
+"$PROJECT_ROOT/scripts/build_laszip.sh"
+
+echo "Compiling save_laz utility..."
+cmake -S "$CODE_DIR" -B "$CODE_DIR/build"
+cmake --build "$CODE_DIR/build" --config Release
+sudo install -m 0755 "$CODE_DIR/build/save_laz" /usr/local/bin/save_laz
 


### PR DESCRIPTION
## Summary
- drop GPIO hardware handling from save_laz utilities
- build LASzip and Livox SDK2 before compiling save_laz

## Testing
- `python -m py_compile save_laz/utils.py webapp/__init__.py webapp/recording_manager.py webapp/logging_config.py`
- `./scripts/compile_save_laz.sh` *(fails: The source directory "/workspace/tecscanner/3rd/Livox-SDK2" does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa1d9d78832ab07448a1e3145396